### PR TITLE
Update openrewrite dependency to 8.45.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ ext {
 	set('jarchivelibVersion', '1.2.0')
 	set('kohsukeVersion', '1.301')
 	set('gitlab4jVersion', '4.19.0')
-	set('openrewriteVersion', '8.13.4')
+	set('openrewriteVersion', '8.45.0')
 	set('antVersion', '1.10.9')
 	set('mavenModelVersion', '3.5.4')
 	set('tikaVersion', '1.18')

--- a/src/main/java/org/springframework/cli/merger/ProjectMerger.java
+++ b/src/main/java/org/springframework/cli/merger/ProjectMerger.java
@@ -614,7 +614,9 @@ public class ProjectMerger {
 			}
 			else {
 				AddRepository recipeAddRepository = getRecipeAddRepository(candidateRepository.getId(),
-						candidateRepository.getUrl(), candidateRepository.getName(), false, false);
+						candidateRepository.getUrl(), candidateRepository.getName(),
+						false, false,
+						AddRepository.Type.Repository);
 				List<SourceFile> pomFiles = mavenParser.parse(paths, this.currentProjectPath, getExecutionContext())
 					.toList();
 				List<Result> resultList = recipeAddRepository
@@ -701,8 +703,8 @@ public class ProjectMerger {
 	}
 
 	public static AddRepository getRecipeAddRepository(String id, String url, String name, boolean snapshotsEnabled,
-			boolean releasesEnabled) {
-		return new AddRepository(id, url, name, null, snapshotsEnabled, null, null, releasesEnabled, null, null);
+			boolean releasesEnabled, AddRepository.Type repositoryType) {
+		return new AddRepository(id, url, name, null, snapshotsEnabled, null, null, releasesEnabled, null, null, repositoryType);
 	}
 
 }

--- a/src/main/java/org/springframework/cli/runtime/engine/actions/handlers/json/ConversionUtils.java
+++ b/src/main/java/org/springframework/cli/runtime/engine/actions/handlers/json/ConversionUtils.java
@@ -21,11 +21,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.openrewrite.shaded.jgit.diff.Edit;
-import org.openrewrite.shaded.jgit.diff.EditList;
-import org.openrewrite.shaded.jgit.diff.HistogramDiff;
-import org.openrewrite.shaded.jgit.diff.RawText;
-import org.openrewrite.shaded.jgit.diff.RawTextComparator;
+import org.openrewrite.jgit.diff.Edit;
+import org.openrewrite.jgit.diff.EditList;
+import org.openrewrite.jgit.diff.HistogramDiff;
+import org.openrewrite.jgit.diff.RawText;
+import org.openrewrite.jgit.diff.RawTextComparator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Small Update to the openrewrite dependency to pull in the latest goodness.
Update from `8.13.4` to `8.45.0`
Migrate package names for jgit usage in openrewrite tools 
Update API around AddRepositoryPlugin usage to make repository type explicit