### PR TITLE
Fix for ProjectMerger.mergeMavenPlugins Xml Declarations Issue

### DIFF
--- a/src/main/java/org/springframework/cli/util/ConversionUtils.java
+++ b/src/main/java/org/springframework/cli/util/ConversionUtils.java
@@ -18,6 +18,8 @@ package org.springframework.cli.util;
 
 import java.io.StringWriter;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXB;
 
@@ -33,17 +35,33 @@ public final class ConversionUtils {
 
 	}
 
+	/**
+	 * Converts Xpp3Dom to a String without any xml declaration
+	 * @param dom the Xpp3Dom to convert
+	 * @return String without any Xml Declarations
+	 */
 	public static String fromDomToString(Xpp3Dom dom) {
 		String element = dom.toString();
-		return element;
+        return element.lines().filter(l -> !l.contains("<?xml")).collect(Collectors.joining("\n"));
 	}
 
+	/**
+	 * Formats a list of Maven Dependencies as a String without the xml declaration
+	 * @param dependencies the list of Maven Dependencies to convert
+	 * @return String without any Xml Declarations or optional and type elements if they contain default values
+	 */
 	public static String fromDependencyListToString(List<Dependency> dependencies) {
 		StringWriter sw = new StringWriter();
+
 		Dependencies deps = new Dependencies(dependencies);
 		JAXB.marshal(deps, sw);
 		String xmlString = sw.toString();
-		return xmlString;
+		// filter out lines containing xml declarations and default elements like:
+		// <optional>false</optional> and <type>jar</type>
+		return xmlString.lines().filter(l -> !l.contains("<?xml") &&
+				!l.contains("<optional>false</optional>") &&
+				!l.contains("<type>jar</type>"))
+				.collect(Collectors.joining("\n"));
 	}
 
 	/*
@@ -52,18 +70,18 @@ public final class ConversionUtils {
 	 */
 	public static class Dependencies {
 
-		private List<Dependency> dependencies;
+		private List<Dependency> dependency;
 
 		public Dependencies(List<Dependency> dependencies) {
-			this.dependencies = dependencies;
+			this.dependency = dependencies;
 		}
 
-		public List<Dependency> getDependencies() {
-			return dependencies;
+		public List<Dependency> getDependency() {
+			return dependency;
 		}
 
-		public void setDependencies(List<Dependency> dependencies) {
-			this.dependencies = dependencies;
+		public void setDependency(List<Dependency> dependencies) {
+			this.dependency = dependencies;
 		}
 
 	}

--- a/src/test/java/org/springframework/cli/merger/MavenModificationTests.java
+++ b/src/test/java/org/springframework/cli/merger/MavenModificationTests.java
@@ -78,7 +78,11 @@ public class MavenModificationTests {
 				pomReader.readPom(pomToMerge.toFile()), paths, mavenParser);
 
 		Model mergedModel = pomReader.readPom(mergedPomPath.toFile());
+		assertThat(mergedModel.getBuild().getPlugins()).hasSize(3);
+		List<String> mergedPluginIds = new ArrayList<>();
 		for (Plugin plugin : mergedModel.getBuild().getPlugins()) {
+
+			mergedPluginIds.add(plugin.getArtifactId());
 			if (plugin.getGroupId().equals("org.apache.maven.plugins")
 					&& plugin.getArtifactId().equals("maven-deploy-plugin")) {
 				assertThat(ConversionUtils.fromDomToString((Xpp3Dom) plugin.getConfiguration()))
@@ -98,6 +102,8 @@ public class MavenModificationTests {
 				assertThat(dep.getArtifactId()).isEqualTo("spring-boot-thin-layout");
 			}
 		}
+		assertThat(mergedPluginIds).containsExactlyInAnyOrder("maven-deploy-plugin", "maven-shade-plugin",
+				"spring-boot-maven-plugin");
 	}
 
 	@Test

--- a/src/test/java/org/springframework/cli/util/ConversionUtilsTest.java
+++ b/src/test/java/org/springframework/cli/util/ConversionUtilsTest.java
@@ -1,0 +1,87 @@
+package org.springframework.cli.util;
+
+import org.apache.maven.model.Dependency;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+//@Disabled("This is a WIP Test")
+class ConversionUtilsTest {
+
+
+
+    @DisplayName("Characterization Test to validate how this current works, note the xml declaration AND the duplicate dependencies element")
+    @Disabled("This test exists to show what was actually coming out of ConversionUtil")
+    @Test
+    void existingFromDependencyListToString() {
+        List<Dependency> dependencies = new ArrayList<>();
+        Dependency dependency = new Dependency();
+        dependency.setGroupId("org.springframework");
+        dependency.setArtifactId("spring-core");
+        dependency.setVersion("5.2.0.RELEASE");
+        dependencies.add(dependency);
+        String result = ConversionUtils.fromDependencyListToString(dependencies);
+        assertThat(result.replaceAll("\\s",""))
+                .isEqualTo("<?xmlversion=\"1.0\"encoding=\"UTF-8\"standalone=\"yes\"?>" +
+                        "<dependencies>" +
+                        "<dependencies>" +
+                        "<artifactId>spring-core</artifactId>" +
+                        "<groupId>org.springframework</groupId>" +
+                        "<optional>false</optional>" +
+                        "<version>5.2.0.RELEASE</version>" +
+                        "</dependencies>" +
+                        "</dependencies>");
+
+    }
+
+    @DisplayName("After ConversionUtils is corrected, this test should pass")
+    @Test
+    void validateFromDependencyListToString() {
+        List<Dependency> dependencies = new ArrayList<>();
+        Dependency dependency = new Dependency();
+        dependency.setGroupId("org.springframework");
+        dependency.setArtifactId("spring-core");
+        dependency.setVersion("5.2.0.RELEASE");
+        dependencies.add(dependency);
+        String result = ConversionUtils.fromDependencyListToString(dependencies);
+        assertThat(result.replaceAll("\\s",""))
+                .isEqualTo("<dependencies>" +
+                        "<dependency>" +
+                        "<artifactId>spring-core</artifactId>" +
+                        "<groupId>org.springframework</groupId>" +
+                        "<version>5.2.0.RELEASE</version>" +
+                        "</dependency>" +
+                        "</dependencies>");
+
+    }
+
+
+    @DisplayName("fromDomToString removes XML declaration")
+    @Test
+    void fromDomToStringRemovesXmlDeclaration() {
+        Xpp3Dom dom = new Xpp3Dom("root");
+        Xpp3Dom child = new Xpp3Dom("child");
+        child.setValue("value");
+        dom.addChild(child);
+        String result = ConversionUtils.fromDomToString(dom);
+        assertThat(result).doesNotContain("<?xml").contains("<root>").contains("</root>").contains("<child>value</child>");
+    }
+
+    @DisplayName("fromDomToString handles empty Xpp3Dom")
+    @Test
+    void fromDomToStringHandlesEmptyXpp3Dom() {
+        Xpp3Dom dom = new Xpp3Dom("root");
+        String result = ConversionUtils.fromDomToString(dom);
+        assertThat(result).isEqualTo("<root/>");
+    }
+
+
+
+
+}


### PR DESCRIPTION
Proposed Fix for ProjectMerger.mergeMavenPlugins Issue
see: https://github.com/spring-projects/spring-cli/issues/217

Discovered while working on a project that was trying to merge some openapi plugin tooling. The ConversionUtil code was returning strings with xml declarations and that was breaking and not working as expectd in the openrewrite recipes that modify the pom's plugins

* Added a Test for ConversionUtil to demonstrate existing behavior
* Added Test for expected ConversionUtil output
* Updated ConversionUtil to avoid returning dependencies with default dependency content
* Updated MavenModificationTests with additional validation around merged/added plugins